### PR TITLE
Fix run_unit_tests.sh color typo

### DIFF
--- a/scripts/ci/testing/run_unit_tests.sh
+++ b/scripts/ci/testing/run_unit_tests.sh
@@ -19,6 +19,7 @@
 export COLOR_RED=$'\e[31m'
 export COLOR_BLUE=$'\e[34m'
 export COLOR_YELLOW=$'\e[33m'
+export COLOR_GREEN=$'\e[32m'
 export COLOR_RESET=$'\e[0m'
 
 if [[ ! "$#" -eq 2 ]]; then
@@ -117,7 +118,7 @@ function providers_tests() {
         echo
         exit "${RESULT}"
     fi
-    echo "${COLOR_GREEB}Providers tests completed successfully${COLOR_RESET}"
+    echo "${COLOR_GREEN}Providers tests completed successfully${COLOR_RESET}"
 }
 
 


### PR DESCRIPTION
## Summary
- add green color variable
- fix success message typo

## Testing
- `bash -u scripts/ci/testing/run_unit_tests.sh foo bar`
- `bash -u scripts/ci/testing/run_unit_tests.sh core Wrong`
- `bash -u scripts/ci/testing/run_unit_tests.sh providers Wrong`
- `bash -n scripts/ci/testing/run_unit_tests.sh`
- ❌ `pre-commit run --files scripts/ci/testing/run_unit_tests.sh` *(failed: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840409bf2cc832199de11d67ba34691