### PR TITLE
Fix test for missing export directory

### DIFF
--- a/airflow-core/tests/unit/cli/test_cli_parser.py
+++ b/airflow-core/tests/unit/cli/test_cli_parser.py
@@ -394,9 +394,15 @@ class TestCli:
         """Test that the error message is correct when the directory does not exist."""
         with contextlib.redirect_stderr(StringIO()) as stderr:
             parser = cli_parser.get_parser()
-            with pytest.raises(SystemExit):
-                parser.parse_args(["db", "export-archived", "--output-path", "/non/existing/directory"])
+            with pytest.raises(SystemExit) as excinfo:
+                parser.parse_args([
+                    "db",
+                    "export-archived",
+                    "--output-path",
+                    "/non/existing/directory",
+                ])
             error_msg = stderr.getvalue()
+        assert excinfo.value.code != 0
 
         assert error_msg == (
             "\nairflow db export-archived command error: The directory "


### PR DESCRIPTION
## Summary
- capture SystemExit object when the output directory for `db export-archived` is missing
- verify the exit code is non-zero

## Testing
- `pytest airflow-core/tests/unit/cli/test_cli_parser.py::TestCli::test_non_existing_directory_raises_when_metavar_is_dir_for_db_export_cleaned -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684040c324948321892c6c248cdd714a